### PR TITLE
Fix: Removed the chest section label selection

### DIFF
--- a/runtime/logistics-handler.lua
+++ b/runtime/logistics-handler.lua
@@ -19,7 +19,7 @@ local function handle_requester(chest, educts_amounts)
     -- Find or create "automatic-logistic-chests" section
     local logistics_section = nil
     for _, section in pairs(logistics_point.sections) do
-        if section and section.valid and section.group == "automatic-logistic-chests" then
+        if section and section.valid and section.group == "" then
             logistics_section = section
             -- Clear existing slots
             for slot_index = 1, section.filters_count do
@@ -27,9 +27,7 @@ local function handle_requester(chest, educts_amounts)
             end
         end
     end
-    if not logistics_section then
-        logistics_section = logistics_point.add_section("automatic-logistic-chests")
-    end
+
     -- If logistics_section is still not valid, exit early
     if not logistics_section or not logistics_section.valid then return end
 


### PR DESCRIPTION
All chests' section with same label share the config. If different chests use same label, these chests will be set to same settings when set the section. Empty label is unique for each chest.